### PR TITLE
Returning a 404 error if the result Optional is empty

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,5 +1,5 @@
-lazy val akkaHttpVersion = "10.0.11"
-lazy val akkaVersion    = "2.5.11"
+lazy val akkaHttpVersion = "$akka_http_version$"
+lazy val akkaVersion    = "$akka_version$"
 
 lazy val root = (project in file(".")).
   settings(

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,5 +1,5 @@
-lazy val akkaHttpVersion = "$akka_http_version$"
-lazy val akkaVersion    = "$akka_version$"
+lazy val akkaHttpVersion = "10.0.11"
+lazy val akkaVersion    = "2.5.11"
 
 lazy val root = (project in file(".")).
   settings(

--- a/src/main/g8/src/main/java/com/lightbend/akka/http/sample/UserRoutes.java
+++ b/src/main/g8/src/main/java/com/lightbend/akka/http/sample/UserRoutes.java
@@ -67,18 +67,14 @@ public class UserRoutes extends AllDirectives {
             .ask(userRegistryActor, new UserRegistryMessages.GetUser(name), timeout)
             .thenApply(obj ->(Optional<User>) obj);
 
-          return rejectEmptyResponse(() ->
-            onSuccess(
-              () -> maybeUser,
+          return onSuccess(() -> maybeUser,
               performed -> {
                   if (performed.isPresent())
-                    return complete(StatusCodes.OK, performed.get(), Jackson.marshaller());
+                      return complete(StatusCodes.OK, performed.get(), Jackson.marshaller());
                   else
-                    return complete(StatusCodes.NOT_FOUND);
-
+                      return complete(StatusCodes.NOT_FOUND);
               }
-            )
-          );
+            );
           //#retrieve-user-info
         });
     }

--- a/src/main/g8/src/main/java/com/lightbend/akka/http/sample/UserRoutes.java
+++ b/src/main/g8/src/main/java/com/lightbend/akka/http/sample/UserRoutes.java
@@ -70,8 +70,13 @@ public class UserRoutes extends AllDirectives {
           return rejectEmptyResponse(() ->
             onSuccess(
               () -> maybeUser,
-              performed ->
-                complete(StatusCodes.OK, (User) performed.get(), Jackson.<User>marshaller())
+              performed -> {
+                  if (performed.isPresent())
+                    return complete(StatusCodes.OK, performed.get(), Jackson.marshaller());
+                  else
+                    return complete(StatusCodes.NOT_FOUND);
+
+              }
             )
           );
           //#retrieve-user-info


### PR DESCRIPTION
Issue #17 
If the user doesn't exist, the performed value Optional is empty then return a 404 error instead of a 500.