### PR TITLE
Make Maven and Gradle use the Akka HTTP BOM; recent versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ scala:
 
 env:
   matrix:
-    - TRAVIS_JDK=adopt@1.8.0-242
-    - TRAVIS_JDK=adopt@1.11.0-6
+    - TRAVIS_JDK=adopt@1.8-0
+    - TRAVIS_JDK=adopt@1.11-0
 
 before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
 install: jabba install "$TRAVIS_JDK" && jabba use "$_" && java -Xmx32m -version
@@ -14,10 +14,11 @@ install: jabba install "$TRAVIS_JDK" && jabba use "$_" && java -Xmx32m -version
 # These directories are cached to S3 at the end of the build
 cache:
   directories:
+    - $HOME/.cache/coursier
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot/
+    - $HOME/.sbt
     - $HOME/.gradle
-    - $HOME/.jabba/jdk
+    - $HOME/.jabba
 
 script:
   ## This runs the template with the default parameters, and runs test within the templated app.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ page.
 
 Prerequisites:
 - JDK 8
-- [sbt][sbt] 0.13.13 or higher ([download here][sbt_download])
+- [sbt][sbt] 1.4.5 or higher ([download here][sbt_download])
 
 Open a console and run the following command to apply this template:
  ```
-sbt -Dsbt.version=0.13.15 new akka/akka-http-java-seed.g8
+sbt -Dsbt.version=1.4.5 new akka/akka-http-java-seed.g8
  ```
 
 This template will prompt for the following parameters. Press `Enter` if the default values suit you:

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.5

--- a/project/giter8.sbt
+++ b/project/giter8.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.11.0")
+addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.13.1")

--- a/project/paradox.sbt
+++ b/project/paradox.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.3.5")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.9.0")

--- a/src/main/g8/build.gradle
+++ b/src/main/g8/build.gradle
@@ -7,15 +7,22 @@ repositories {
     mavenLocal()
 }
 
+def versions = [
+    AkkaVersion: "$akka_version$",
+    AkkaHttpVersion: "$akka_http_version$",
+    ScalaBinary: "2.13"
+]
 dependencies {
-    compile 'com.typesafe.akka:akka-http_2.13:$akka_http_version$'
-    compile 'com.typesafe.akka:akka-http-jackson_2.13:$akka_http_version$'
-    compile 'com.typesafe.akka:akka-actor-typed_2.13:$akka_version$'
-    compile 'com.typesafe.akka:akka-stream_2.13:$akka_version$'
-    compile 'ch.qos.logback:logback-classic:1.2.3'
-    testCompile 'com.typesafe.akka:akka-http-testkit_2.13:$akka_http_version$'
-    testCompile 'com.typesafe.akka:akka-actor-testkit-typed_2.13:$akka_version$'
-    testCompile 'junit:junit:4.12'
+    implementation platform("com.typesafe.akka:akka-http-bom_\${versions.ScalaBinary}:\${versions.AkkaHttpVersion}")
+
+    implementation "com.typesafe.akka:akka-http_\${versions.ScalaBinary}"
+    implementation "com.typesafe.akka:akka-http-jackson_\${versions.ScalaBinary}"
+    implementation "com.typesafe.akka:akka-actor-typed_\${versions.ScalaBinary}:\${versions.AkkaVersion}"
+    implementation "com.typesafe.akka:akka-stream_\${versions.ScalaBinary}:\${versions.AkkaVersion}"
+    implementation 'ch.qos.logback:logback-classic:1.2.3'
+    testImplementation "com.typesafe.akka:akka-http-testkit_\${versions.ScalaBinary}"
+    testImplementation "com.typesafe.akka:akka-actor-testkit-typed_\${versions.ScalaBinary}:\${versions.AkkaVersion}"
+    testImplementation 'junit:junit:4.12'
 }
 
 mainClassName = "$package$.QuickstartApp"

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,5 +1,5 @@
-lazy val akkaHttpVersion = "$akka_http_version$"
-lazy val akkaVersion    = "$akka_version$"
+val akkaHttpVersion = "$akka_http_version$"
+val akkaVersion    = "$akka_version$"
 
 lazy val root = (project in file(".")).
   settings(

--- a/src/main/g8/pom.xml
+++ b/src/main/g8/pom.xml
@@ -6,26 +6,43 @@
     <artifactId>akka-http-seed-java</artifactId>
     <version>1.0</version>
 
+    <properties>
+        <akka.version>$akka_version$</akka.version>
+        <akka.http.version>$akka_http_version$</akka.http.version>
+        <scala.binary.version>2.13</scala.binary.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.typesafe.akka</groupId>
+                <artifactId>akka-http-bom_\${scala.binary.version}</artifactId>
+                <version>\${akka.http.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-http_2.13</artifactId>
-            <version>$akka_http_version$</version>
+            <artifactId>akka-http_\${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-actor-typed_2.13</artifactId>
-            <version>$akka_version$</version>
+            <artifactId>akka-actor-typed_\${scala.binary.version}</artifactId>
+            <version>\${akka.version}</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-stream_2.13</artifactId>
-            <version>$akka_version$</version>
+            <artifactId>akka-stream_\${scala.binary.version}</artifactId>
+            <version>\${akka.version}</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-http-jackson_2.13</artifactId>
-            <version>$akka_http_version$</version>
+            <artifactId>akka-http-jackson_\${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -34,14 +51,13 @@
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-http-testkit_2.13</artifactId>
-            <version>$akka_http_version$</version>
+            <artifactId>akka-http-testkit_\${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-actor-testkit-typed_2.13</artifactId>
-            <version>$akka_version$</version>
+            <artifactId>akka-actor-testkit-typed_\${scala.binary.version}</artifactId>
+            <version>\${akka.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -58,8 +74,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -72,7 +88,4 @@
             </plugin>
         </plugins>
     </build>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
 </project>

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.5


### PR DESCRIPTION
Makes use of the Maven BOM for Akka HTTP 10.2.2 (but won't allow versions prior to that).

Use version properties in Maven and a version map in Gradle.